### PR TITLE
Changed http status code label to "code"

### DIFF
--- a/src/main/scala/com/github/norwae/ignifera/HttpCollectors.scala
+++ b/src/main/scala/com/github/norwae/ignifera/HttpCollectors.scala
@@ -16,7 +16,7 @@ class HttpCollectors(config: Config) {
     register()
   val requestsTotal: Counter = Counter.
     build("http_requests_total", "Requests processed by the application").
-    labelNames("method", "status").
+    labelNames("method", "code").
     register()
   val requestTimes: Summary = quantize(Summary.
     build("http_request_duration_microseconds", "Time to response determined")).


### PR DESCRIPTION
Hi,

since most integrations of prometheus http stats are using `code` as label to hold the HTTP status code, I suggest to implement it that way.

Appreciate your feedback.

Cheers 